### PR TITLE
fix(deps): ignore faraday 1.x adapter major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,38 @@ updates:
   - dependency-name: activesupport
     versions:
     - 5.2.4.5
+  # github_api 0.19.0 constrains faraday <2, so the faraday 1.x
+  # adapters cannot be bumped to 2.x without replacing github_api.
+  - dependency-name: faraday
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-httpclient
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-patron
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-net_http
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-em_http
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-em_synchrony
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-excon
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-multipart
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-net_http_persistent
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-rack
+    update-types:
+    - version-update:semver-major
+  - dependency-name: faraday-retry
+    update-types:
+    - version-update:semver-major


### PR DESCRIPTION
## Summary
- Ignore `version-update:semver-major` for the faraday adapter family in `dependabot.yml`.

## Why
`github_api` 0.19.0 (latest) pins `faraday >= 0.8, < 2`. Faraday 2.x splits adapters into separate 2.x gems. Dependabot's resolver crashes (`unknown_error`) on `faraday-httpclient`, `faraday-patron`, `faraday-net_http`, etc. when it tries to bump them past the 1.x line. Ignoring major bumps stops the daily run from crashing while github_api still constrains us to faraday 1.x.

## Test plan
- [ ] Next Dependabot run completes successfully

Closes unhappychoice/oss-issue-opener#151

🤖 Generated with [Claude Code](https://claude.com/claude-code)