### PR TITLE
fix(deps): ignore parallel major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,7 @@ updates:
   - dependency-name: faraday-retry
     update-types:
     - version-update:semver-major
+  # parallel 2.x requires Ruby >= 3.3; this site still runs on Ruby 3.2.
+  - dependency-name: parallel
+    update-types:
+    - version-update:semver-major


### PR DESCRIPTION
parallel 2.x requires Ruby >= 3.3, but this site still targets Ruby 3.2.
Without this guard Dependabot crashes with `Error processing parallel
(RuntimeError)` when it tries to bump parallel, which also blocks unrelated
security updates (jwt) from being opened.

Closes unhappychoice/oss-issue-opener#198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to prevent incompatible dependency updates and maintain application stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/blog/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->