### PR TITLE
chore(ci): use personal git identity for automated commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Setup git
         run: |
-          git config --global user.name 'GitHub Actions'
+          git config --global user.name 'Yuji Ueki'
           git config --global user.email 'unhappychoice@gmail.com'
 
       - name: Setup SSH


### PR DESCRIPTION
Automated commits made by GitHub Actions in this repository were authored as a bot (or under an inconsistent name). This switches them to `Yuji Ueki <unhappychoice@gmail.com>` so the history and contribution graph reflect the actual author.

Workflow logic is unchanged — only the configured commit identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow to use the designated commit author name for automated deployment commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->